### PR TITLE
Do not assume http_response_header set during exception

### DIFF
--- a/lib/Consumer.php
+++ b/lib/Consumer.php
@@ -91,16 +91,19 @@ class Consumer
             $statuscode = 'unknown';
 
             /** @psalm-suppress UndefinedVariable */
-            if (preg_match('/^HTTP.*\s([0-9]{3})/', $http_response_header[0], $matches)) {
-                $statuscode = $matches[1];
-            }
+            if (!empty($http_response_header)) {
+                /** @psalm-suppress UndefinedVariable */
+                if (preg_match('/^HTTP.*\s([0-9]{3})/', $http_response_header[0], $matches)) {
+                    $statuscode = $matches[1];
+                }
 
-            $error = $context . ' [statuscode: ' . $statuscode . ']: ';
-            /** @psalm-suppress UndefinedVariable */
-            $oautherror = self::getOAuthError($http_response_header);
+                $error = $context . ' [statuscode: ' . $statuscode . ']: ';
+                /** @psalm-suppress UndefinedVariable */
+                $oautherror = self::getOAuthError($http_response_header);
 
-            if (!empty($oautherror)) {
-                $error .= $oautherror;
+                if (!empty($oautherror)) {
+                    $error .= $oautherror;
+                }
             }
 
             throw new \Exception($error . ':' . $url);


### PR DESCRIPTION
The variable $http_response_header may not be set during an exception. A
typical use case is calling out to the Twitter API during Twitter
authentication when the callback URI has not been registered with
Twitter. Because of how the Twitter API responds $http_response_header
is not set and during the handling of the exception the missing
$http_response_header masks the real issue. This commit changes the code
to not assume that $http_response_header is set.