### PR TITLE
PHP 7.4 Incompatibility Fix

### DIFF
--- a/libextinc/OAuth.php
+++ b/libextinc/OAuth.php
@@ -159,7 +159,7 @@ abstract class OAuthSignatureMethod
         // Avoid a timing leak with a (hopefully) time insensitive compare
         $result = 0;
         for ($i = 0; $i < strlen($signature); $i++) {
-            $result |= ord($built{$i}) ^ ord($signature{$i});
+            $result |= ord($built[$i]) ^ ord($signature[$i]);
         }
 
         return $result == 0;


### PR DESCRIPTION
Curly brace syntax for accessing array elements and string offsets has been deprecated in PHP 7.4.